### PR TITLE
Fix building of test file.

### DIFF
--- a/ir_test.go
+++ b/ir_test.go
@@ -31,7 +31,7 @@ func testAttribute(t *testing.T, name string) {
 	fn.AddFunctionAttr(attr)
 	newattr := fn.GetEnumFunctionAttribute(kind)
 	if attr != newattr {
-		t.Errorf("got attribute mask %d, want %d", newattr, attr)
+		t.Errorf("got attribute mask %d, want %d", newattr.C, attr.C)
 	}
 
 	text := mod.String()
@@ -42,7 +42,7 @@ func testAttribute(t *testing.T, name string) {
 	fn.RemoveEnumFunctionAttribute(kind)
 	newattr = fn.GetEnumFunctionAttribute(kind)
 	if !newattr.IsNil() {
-		t.Errorf("got attribute mask %d, want 0", newattr)
+		t.Errorf("got attribute mask %d, want 0", newattr.C)
 	}
 }
 


### PR DESCRIPTION
Trying to run `go test` here produces:
```
./ir_test.go:34:3: Errorf format %d has arg newattr of wrong type tinygo.org/x/go-llvm.Attribute
./ir_test.go:45:3: Errorf format %d has arg newattr of wrong type tinygo.org/x/go-llvm.Attribute
```
because `Attribute` seems to be a wrapper `struct` around the thing.