### PR TITLE
Support LLVM 9

### DIFF
--- a/IRBindings.cpp
+++ b/IRBindings.cpp
@@ -51,7 +51,7 @@ void LLVMSetMetadata2(LLVMValueRef Inst, unsigned KindID, LLVMMetadataRef MD) {
   unwrap<Instruction>(Inst)->setMetadata(KindID, N);
 }
 
-void LLVMSetCurrentDebugLocation2(LLVMBuilderRef Bref, unsigned Line,
+void LLVMGoSetCurrentDebugLocation(LLVMBuilderRef Bref, unsigned Line,
                                   unsigned Col, LLVMMetadataRef Scope,
                                   LLVMMetadataRef InlinedAt) {
   unwrap(Bref)->SetCurrentDebugLocation(
@@ -59,7 +59,7 @@ void LLVMSetCurrentDebugLocation2(LLVMBuilderRef Bref, unsigned Line,
                     InlinedAt ? unwrap<MDNode>(InlinedAt) : nullptr));
 }
 
-LLVMDebugLocMetadata LLVMGetCurrentDebugLocation2(LLVMBuilderRef Bref) {
+LLVMDebugLocMetadata LLVMGoGetCurrentDebugLocation(LLVMBuilderRef Bref) {
   const auto& Loc = unwrap(Bref)->getCurrentDebugLocation();
   const auto* InlinedAt = Loc.getInlinedAt();
   const LLVMDebugLocMetadata md{

--- a/IRBindings.h
+++ b/IRBindings.h
@@ -44,11 +44,11 @@ void LLVMAddNamedMetadataOperand2(LLVMModuleRef M, const char *name,
                                   LLVMMetadataRef Val);
 void LLVMSetMetadata2(LLVMValueRef Inst, unsigned KindID, LLVMMetadataRef MD);
 
-void LLVMSetCurrentDebugLocation2(LLVMBuilderRef Bref, unsigned Line,
+void LLVMGoSetCurrentDebugLocation(LLVMBuilderRef Bref, unsigned Line,
                                   unsigned Col, LLVMMetadataRef Scope,
                                   LLVMMetadataRef InlinedAt);
 
-struct LLVMDebugLocMetadata LLVMGetCurrentDebugLocation2(LLVMBuilderRef Bref);
+struct LLVMDebugLocMetadata LLVMGoGetCurrentDebugLocation(LLVMBuilderRef Bref);
 
 #ifdef __cplusplus
 }

--- a/InstrumentationBindings.cpp
+++ b/InstrumentationBindings.cpp
@@ -16,6 +16,9 @@
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Transforms/Instrumentation.h"
+#if LLVM_VERSION_MAJOR >= 9
+#include "llvm/Transforms/Instrumentation/AddressSanitizer.h"
+#endif
 #include "llvm/Transforms/Instrumentation/MemorySanitizer.h"
 #include "llvm/Transforms/Instrumentation/ThreadSanitizer.h"
 
@@ -26,7 +29,11 @@ void LLVMAddAddressSanitizerFunctionPass(LLVMPassManagerRef PM) {
 }
 
 void LLVMAddAddressSanitizerModulePass(LLVMPassManagerRef PM) {
+#if LLVM_VERSION_MAJOR >= 9
+  unwrap(PM)->add(createModuleAddressSanitizerLegacyPassPass());
+#else
   unwrap(PM)->add(createAddressSanitizerModulePass());
+#endif
 }
 
 void LLVMAddThreadSanitizerPass(LLVMPassManagerRef PM) {

--- a/ir.go
+++ b/ir.go
@@ -1302,11 +1302,11 @@ type DebugLoc struct {
 	InlinedAt      Metadata
 }
 func (b Builder) SetCurrentDebugLocation(line, col uint, scope, inlinedAt Metadata) {
-	C.LLVMSetCurrentDebugLocation2(b.C, C.unsigned(line), C.unsigned(col), scope.C, inlinedAt.C)
+	C.LLVMGoSetCurrentDebugLocation(b.C, C.unsigned(line), C.unsigned(col), scope.C, inlinedAt.C)
 }
 // Get current debug location. Please do not call this function until setting debug location with SetCurrentDebugLocation()
 func (b Builder) GetCurrentDebugLocation() (loc DebugLoc) {
-	md := C.LLVMGetCurrentDebugLocation2(b.C)
+	md := C.LLVMGoGetCurrentDebugLocation(b.C)
 	loc.Line = uint(md.Line)
 	loc.Col = uint(md.Col)
 	loc.Scope = Metadata{C: md.Scope}


### PR DESCRIPTION
This backports a couple of changes that fix compilation against LLVM 9. As I assume you want to continue supporting LLVM 8 (I do, for now), these changes are made conditional where necessary.

See commit messages for details.