### PR TITLE
Sync with source files from LLVM 9.0.1 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ config:
 	@echo "// #cgo LDFLAGS: $(LDFLAGS)" >> llvm_config_$(GOOS).go
 	@echo "import \"C\"" >> llvm_config_$(GOOS).go
 	@echo "" >> llvm_config_$(GOOS).go
-	@echo "type (run_build_sh int)" >> llvm_config_$(GOOS).go
+	@echo "type run_build_sh int" >> llvm_config_$(GOOS).go
 
 update: $(SRCDIR) clean
 	@cp -rp "$(SRCDIR)"/bindings/go/llvm/*.go .

--- a/backports.go
+++ b/backports.go
@@ -11,7 +11,7 @@ import "C"
 // https://reviews.llvm.org/D51642 (in progress)
 
 func (pmb PassManagerBuilder) AddCoroutinePassesToExtensionPoints() {
-	C.LLVMPassManagerBuilderAddCoroutinePassesToExtensionPoints_backport(pmb.C);
+	C.LLVMPassManagerBuilderAddCoroutinePassesToExtensionPoints_backport(pmb.C)
 }
 
 // Erase instruction

--- a/backports.go
+++ b/backports.go
@@ -14,27 +14,7 @@ func (pmb PassManagerBuilder) AddCoroutinePassesToExtensionPoints() {
 	C.LLVMPassManagerBuilderAddCoroutinePassesToExtensionPoints_backport(pmb.C)
 }
 
-// Erase instruction
-// https://reviews.llvm.org/D52694 (in progress)
+// Remove instruction
+// https://reviews.llvm.org/D72209 (in progress)
 
-func (v Value) EraseFromParentAsInstruction()  { C.LLVMInstructionEraseFromParent(v.C) }
 func (v Value) RemoveFromParentAsInstruction() { C.LLVMInstructionRemoveFromParent(v.C) }
-
-// Called function from a CallInst
-// https://reviews.llvm.org/D52972 (in progress)
-
-func (v Value) CalledValue() (rv Value) {
-	rv.C = C.LLVMGetCalledValue(v.C)
-	return
-}
-
-// Predicates
-// https://reviews.llvm.org/D53884 (in progress)
-
-func (v Value) IntPredicate() IntPredicate {
-	return IntPredicate(C.LLVMGetICmpPredicate(v.C))
-}
-
-func (v Value) FloatPredicate() FloatPredicate {
-	return FloatPredicate(C.LLVMGetFCmpPredicate(v.C))
-}

--- a/dibuilder.go
+++ b/dibuilder.go
@@ -343,11 +343,11 @@ func (d *DIBuilder) CreateBasicType(t DIBasicType) Metadata {
 
 // DIPointerType holds the values for creating pointer type debug metadata.
 type DIPointerType struct {
-	Pointee     Metadata
-	SizeInBits  uint64
-	AlignInBits uint32 // optional
+	Pointee      Metadata
+	SizeInBits   uint64
+	AlignInBits  uint32 // optional
 	AddressSpace uint32
-	Name        string // optional
+	Name         string // optional
 }
 
 // CreatePointerType creates a type that represents a pointer to another type.
@@ -393,14 +393,14 @@ func (d *DIBuilder) CreateSubroutineType(t DISubroutineType) Metadata {
 
 // DIStructType holds the values for creating struct type debug metadata.
 type DIStructType struct {
-	Name        string
-	File        Metadata
-	Line        int
-	SizeInBits  uint64
-	AlignInBits uint32
-	Flags       int
-	DerivedFrom Metadata
-	Elements    []Metadata
+	Name         string
+	File         Metadata
+	Line         int
+	SizeInBits   uint64
+	AlignInBits  uint32
+	Flags        int
+	DerivedFrom  Metadata
+	Elements     []Metadata
 	VTableHolder Metadata // optional
 	UniqueID     string
 }
@@ -619,7 +619,7 @@ func (d *DIBuilder) InsertValueAtEnd(v Value, diVarInfo, expr Metadata, l DebugL
 }
 
 func (v Value) SetSubprogram(sp Metadata) {
-  C.LLVMSetSubprogram(v.C, sp.C)
+	C.LLVMSetSubprogram(v.C, sp.C)
 }
 
 func (v Value) Subprogram() (md Metadata) {

--- a/ir.go
+++ b/ir.go
@@ -65,6 +65,8 @@ type (
 		C C.LLVMAttributeRef
 	}
 	Opcode              C.LLVMOpcode
+	AtomicRMWBinOp      C.LLVMAtomicRMWBinOp
+	AtomicOrdering      C.LLVMAtomicOrdering
 	TypeKind            C.LLVMTypeKind
 	Linkage             C.LLVMLinkage
 	Visibility          C.LLVMVisibility
@@ -191,6 +193,30 @@ const (
 	ShuffleVector  Opcode = C.LLVMShuffleVector
 	ExtractValue   Opcode = C.LLVMExtractValue
 	InsertValue    Opcode = C.LLVMInsertValue
+)
+
+const (
+	AtomicRMWBinOpXchg AtomicRMWBinOp = C.LLVMAtomicRMWBinOpXchg
+	AtomicRMWBinOpAdd  AtomicRMWBinOp = C.LLVMAtomicRMWBinOpAdd
+	AtomicRMWBinOpSub  AtomicRMWBinOp = C.LLVMAtomicRMWBinOpSub
+	AtomicRMWBinOpAnd  AtomicRMWBinOp = C.LLVMAtomicRMWBinOpAnd
+	AtomicRMWBinOpNand AtomicRMWBinOp = C.LLVMAtomicRMWBinOpNand
+	AtomicRMWBinOpOr   AtomicRMWBinOp = C.LLVMAtomicRMWBinOpOr
+	AtomicRMWBinOpXor  AtomicRMWBinOp = C.LLVMAtomicRMWBinOpXor
+	AtomicRMWBinOpMax  AtomicRMWBinOp = C.LLVMAtomicRMWBinOpMax
+	AtomicRMWBinOpMin  AtomicRMWBinOp = C.LLVMAtomicRMWBinOpMin
+	AtomicRMWBinOpUMax AtomicRMWBinOp = C.LLVMAtomicRMWBinOpUMax
+	AtomicRMWBinOpUMin AtomicRMWBinOp = C.LLVMAtomicRMWBinOpUMin
+)
+
+const (
+	AtomicOrderingNotAtomic              AtomicOrdering = C.LLVMAtomicOrderingNotAtomic
+	AtomicOrderingUnordered              AtomicOrdering = C.LLVMAtomicOrderingUnordered
+	AtomicOrderingMonotonic              AtomicOrdering = C.LLVMAtomicOrderingMonotonic
+	AtomicOrderingAcquire                AtomicOrdering = C.LLVMAtomicOrderingAcquire
+	AtomicOrderingRelease                AtomicOrdering = C.LLVMAtomicOrderingRelease
+	AtomicOrderingAcquireRelease         AtomicOrdering = C.LLVMAtomicOrderingAcquireRelease
+	AtomicOrderingSequentiallyConsistent AtomicOrdering = C.LLVMAtomicOrderingSequentiallyConsistent
 )
 
 //-------------------------------------------------------------------------
@@ -1045,6 +1071,26 @@ func (v Value) IsGlobalConstant() bool    { return C.LLVMIsGlobalConstant(v.C) !
 func (v Value) SetGlobalConstant(gc bool) { C.LLVMSetGlobalConstant(v.C, boolToLLVMBool(gc)) }
 func (v Value) IsVolatile() bool          { return C.LLVMGetVolatile(v.C) != 0 }
 func (v Value) SetVolatile(volatile bool) { C.LLVMSetVolatile(v.C, boolToLLVMBool(volatile)) }
+func (v Value) Ordering() AtomicOrdering  { return AtomicOrdering(C.LLVMGetOrdering(v.C)) }
+func (v Value) SetOrdering(ordering AtomicOrdering) {
+	C.LLVMSetOrdering(v.C, C.LLVMAtomicOrdering(ordering))
+}
+func (v Value) IsAtomicSingleThread() bool { return C.LLVMIsAtomicSingleThread(v.C) != 0 }
+func (v Value) SetAtomicSingleThread(singleThread bool) {
+	C.LLVMSetAtomicSingleThread(v.C, boolToLLVMBool(singleThread))
+}
+func (v Value) CmpXchgSuccessOrdering() AtomicOrdering {
+	return AtomicOrdering(C.LLVMGetCmpXchgSuccessOrdering(v.C))
+}
+func (v Value) SetCmpXchgSuccessOrdering(ordering AtomicOrdering) {
+	C.LLVMSetCmpXchgSuccessOrdering(v.C, C.LLVMAtomicOrdering(ordering))
+}
+func (v Value) CmpXchgFailureOrdering() AtomicOrdering {
+	return AtomicOrdering(C.LLVMGetCmpXchgFailureOrdering(v.C))
+}
+func (v Value) SetCmpXchgFailureOrdering(ordering AtomicOrdering) {
+	C.LLVMSetCmpXchgFailureOrdering(v.C, C.LLVMAtomicOrdering(ordering))
+}
 
 // Operations on aliases
 func AddAlias(m Module, t Type, aliasee Value, name string) (v Value) {
@@ -1209,6 +1255,7 @@ func (bb BasicBlock) MoveBefore(pos BasicBlock) { C.LLVMMoveBasicBlockBefore(bb.
 func (bb BasicBlock) MoveAfter(pos BasicBlock)  { C.LLVMMoveBasicBlockAfter(bb.C, pos.C) }
 
 // Operations on instructions
+func (v Value) EraseFromParentAsInstruction()      { C.LLVMInstructionEraseFromParent(v.C) }
 func (v Value) InstructionParent() (bb BasicBlock) { bb.C = C.LLVMGetInstructionParent(v.C); return }
 func (v Value) InstructionDebugLoc() (md Metadata) { md.C = C.LLVMInstructionGetDebugLoc(v.C); return }
 func (v Value) InstructionSetDebugLoc(md Metadata) { C.LLVMInstructionSetDebugLoc(v.C, md.C) }
@@ -1229,6 +1276,10 @@ func (v Value) AddCallSiteAttribute(i int, a Attribute) {
 }
 func (v Value) SetInstrParamAlignment(i int, align int) {
 	C.LLVMSetInstrParamAlignment(v.C, C.unsigned(i), C.unsigned(align))
+}
+func (v Value) CalledValue() (rv Value) {
+	rv.C = C.LLVMGetCalledValue(v.C)
+	return
 }
 
 // Operations on call instructions (only)
@@ -1272,6 +1323,10 @@ func (v Value) Indices() []uint32 {
 	}
 	return indices
 }
+
+// Operations on comparisons
+func (v Value) IntPredicate() IntPredicate     { return IntPredicate(C.LLVMGetICmpPredicate(v.C)) }
+func (v Value) FloatPredicate() FloatPredicate { return FloatPredicate(C.LLVMGetFCmpPredicate(v.C)) }
 
 //-------------------------------------------------------------------------
 // llvm.Builder
@@ -1625,6 +1680,14 @@ func (b Builder) CreateGlobalStringPtr(str, name string) (v Value) {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 	v.C = C.LLVMBuildGlobalStringPtr(b.C, cstr, cname)
+	return
+}
+func (b Builder) CreateAtomicRMW(op AtomicRMWBinOp, ptr, val Value, ordering AtomicOrdering, singleThread bool) (v Value) {
+	v.C = C.LLVMBuildAtomicRMW(b.C, C.LLVMAtomicRMWBinOp(op), ptr.C, val.C, C.LLVMAtomicOrdering(ordering), boolToLLVMBool(singleThread))
+	return
+}
+func (b Builder) CreateAtomicCmpXchg(ptr, cmp, newVal Value, successOrdering, failureOrdering AtomicOrdering, singleThread bool) (v Value) {
+	v.C = C.LLVMBuildAtomicCmpXchg(b.C, ptr.C, cmp.C, newVal.C, C.LLVMAtomicOrdering(successOrdering), C.LLVMAtomicOrdering(failureOrdering), boolToLLVMBool(singleThread))
 	return
 }
 

--- a/ir.go
+++ b/ir.go
@@ -359,49 +359,49 @@ func AttributeKindID(name string) (id uint) {
 }
 
 func (c Context) CreateEnumAttribute(kind uint, val uint64) (a Attribute) {
-  a.C = C.LLVMCreateEnumAttribute(c.C, C.unsigned(kind), C.uint64_t(val))
-  return
+	a.C = C.LLVMCreateEnumAttribute(c.C, C.unsigned(kind), C.uint64_t(val))
+	return
 }
 
 func (a Attribute) GetEnumKind() (id int) {
-  id = int(C.LLVMGetEnumAttributeKind(a.C))
-  return
+	id = int(C.LLVMGetEnumAttributeKind(a.C))
+	return
 }
 
 func (a Attribute) GetEnumValue() (val uint64) {
-  val = uint64(C.LLVMGetEnumAttributeValue(a.C))
-  return
+	val = uint64(C.LLVMGetEnumAttributeValue(a.C))
+	return
 }
 
 func (c Context) CreateStringAttribute(kind string, val string) (a Attribute) {
-  ckind := C.CString(kind)
-  defer C.free(unsafe.Pointer(ckind))
-  cval := C.CString(val)
-  defer C.free(unsafe.Pointer(cval))
-  a.C = C.LLVMCreateStringAttribute(c.C,
-                                    ckind, C.unsigned(len(kind)),
-                                    cval, C.unsigned(len(val)))
-  return
+	ckind := C.CString(kind)
+	defer C.free(unsafe.Pointer(ckind))
+	cval := C.CString(val)
+	defer C.free(unsafe.Pointer(cval))
+	a.C = C.LLVMCreateStringAttribute(c.C,
+		ckind, C.unsigned(len(kind)),
+		cval, C.unsigned(len(val)))
+	return
 }
 
 func (a Attribute) GetStringKind() string {
-  length := C.unsigned(0)
-  ckind := C.LLVMGetStringAttributeKind(a.C, &length)
-  return C.GoStringN(ckind, C.int(length))
+	length := C.unsigned(0)
+	ckind := C.LLVMGetStringAttributeKind(a.C, &length)
+	return C.GoStringN(ckind, C.int(length))
 }
 
 func (a Attribute) GetStringValue() string {
-  length := C.unsigned(0)
-  ckind := C.LLVMGetStringAttributeValue(a.C, &length)
-  return C.GoStringN(ckind, C.int(length))
+	length := C.unsigned(0)
+	ckind := C.LLVMGetStringAttributeValue(a.C, &length)
+	return C.GoStringN(ckind, C.int(length))
 }
 
 func (a Attribute) IsEnum() bool {
-  return C.LLVMIsEnumAttribute(a.C) != 0;
+	return C.LLVMIsEnumAttribute(a.C) != 0
 }
 
 func (a Attribute) IsString() bool {
-  return C.LLVMIsStringAttribute(a.C) != 0;
+	return C.LLVMIsStringAttribute(a.C) != 0
 }
 
 //-------------------------------------------------------------------------
@@ -1105,36 +1105,36 @@ func (v Value) SetGC(name string) {
 	C.LLVMSetGC(v.C, cname)
 }
 func (v Value) AddAttributeAtIndex(i int, a Attribute) {
-  C.LLVMAddAttributeAtIndex(v.C, C.LLVMAttributeIndex(i), a.C)
+	C.LLVMAddAttributeAtIndex(v.C, C.LLVMAttributeIndex(i), a.C)
 }
 func (v Value) AddFunctionAttr(a Attribute) {
-  v.AddAttributeAtIndex(C.LLVMAttributeFunctionIndex, a);
+	v.AddAttributeAtIndex(C.LLVMAttributeFunctionIndex, a)
 }
 func (v Value) GetEnumAttributeAtIndex(i int, kind uint) (a Attribute) {
-  a.C = C.LLVMGetEnumAttributeAtIndex(v.C, C.LLVMAttributeIndex(i), C.unsigned(kind))
-  return
+	a.C = C.LLVMGetEnumAttributeAtIndex(v.C, C.LLVMAttributeIndex(i), C.unsigned(kind))
+	return
 }
 func (v Value) GetEnumFunctionAttribute(kind uint) Attribute {
-  return v.GetEnumAttributeAtIndex(C.LLVMAttributeFunctionIndex, kind)
+	return v.GetEnumAttributeAtIndex(C.LLVMAttributeFunctionIndex, kind)
 }
 func (v Value) GetStringAttributeAtIndex(i int, kind string) (a Attribute) {
-  ckind := C.CString(kind)
-  defer C.free(unsafe.Pointer(ckind))
-  a.C = C.LLVMGetStringAttributeAtIndex(v.C, C.LLVMAttributeIndex(i),
-                                        ckind, C.unsigned(len(kind)))
-  return
+	ckind := C.CString(kind)
+	defer C.free(unsafe.Pointer(ckind))
+	a.C = C.LLVMGetStringAttributeAtIndex(v.C, C.LLVMAttributeIndex(i),
+		ckind, C.unsigned(len(kind)))
+	return
 }
 func (v Value) RemoveEnumAttributeAtIndex(i int, kind uint) {
-  C.LLVMRemoveEnumAttributeAtIndex(v.C, C.LLVMAttributeIndex(i), C.unsigned(kind))
+	C.LLVMRemoveEnumAttributeAtIndex(v.C, C.LLVMAttributeIndex(i), C.unsigned(kind))
 }
 func (v Value) RemoveEnumFunctionAttribute(kind uint) {
-  v.RemoveEnumAttributeAtIndex(C.LLVMAttributeFunctionIndex, kind);
+	v.RemoveEnumAttributeAtIndex(C.LLVMAttributeFunctionIndex, kind)
 }
 func (v Value) RemoveStringAttributeAtIndex(i int, kind string) {
-  ckind := C.CString(kind)
-  defer C.free(unsafe.Pointer(ckind))
-  C.LLVMRemoveStringAttributeAtIndex(v.C, C.LLVMAttributeIndex(i),
-                                     ckind, C.unsigned(len(kind)))
+	ckind := C.CString(kind)
+	defer C.free(unsafe.Pointer(ckind))
+	C.LLVMRemoveStringAttributeAtIndex(v.C, C.LLVMAttributeIndex(i),
+		ckind, C.unsigned(len(kind)))
 }
 func (v Value) AddTargetDependentFunctionAttr(attr, value string) {
 	cattr := C.CString(attr)
@@ -1156,12 +1156,12 @@ func (v Value) Params() []Value {
 	}
 	return out
 }
-func (v Value) Param(i int) (rv Value)  { rv.C = C.LLVMGetParam(v.C, C.unsigned(i)); return }
-func (v Value) ParamParent() (rv Value) { rv.C = C.LLVMGetParamParent(v.C); return }
-func (v Value) FirstParam() (rv Value)  { rv.C = C.LLVMGetFirstParam(v.C); return }
-func (v Value) LastParam() (rv Value)   { rv.C = C.LLVMGetLastParam(v.C); return }
-func NextParam(v Value) (rv Value)      { rv.C = C.LLVMGetNextParam(v.C); return }
-func PrevParam(v Value) (rv Value)      { rv.C = C.LLVMGetPreviousParam(v.C); return }
+func (v Value) Param(i int) (rv Value)      { rv.C = C.LLVMGetParam(v.C, C.unsigned(i)); return }
+func (v Value) ParamParent() (rv Value)     { rv.C = C.LLVMGetParamParent(v.C); return }
+func (v Value) FirstParam() (rv Value)      { rv.C = C.LLVMGetFirstParam(v.C); return }
+func (v Value) LastParam() (rv Value)       { rv.C = C.LLVMGetLastParam(v.C); return }
+func NextParam(v Value) (rv Value)          { rv.C = C.LLVMGetNextParam(v.C); return }
+func PrevParam(v Value) (rv Value)          { rv.C = C.LLVMGetPreviousParam(v.C); return }
 func (v Value) SetParamAlignment(align int) { C.LLVMSetParamAlignment(v.C, C.unsigned(align)) }
 
 // Operations on basic blocks
@@ -1299,13 +1299,15 @@ func (b Builder) Dispose() { C.LLVMDisposeBuilder(b.C) }
 
 // Metadata
 type DebugLoc struct {
-	Line, Col      uint
-	Scope          Metadata
-	InlinedAt      Metadata
+	Line, Col uint
+	Scope     Metadata
+	InlinedAt Metadata
 }
+
 func (b Builder) SetCurrentDebugLocation(line, col uint, scope, inlinedAt Metadata) {
 	C.LLVMGoSetCurrentDebugLocation(b.C, C.unsigned(line), C.unsigned(col), scope.C, inlinedAt.C)
 }
+
 // Get current debug location. Please do not call this function until setting debug location with SetCurrentDebugLocation()
 func (b Builder) GetCurrentDebugLocation() (loc DebugLoc) {
 	md := C.LLVMGoGetCurrentDebugLocation(b.C)

--- a/llvm_config_darwin.go
+++ b/llvm_config_darwin.go
@@ -9,4 +9,4 @@ package llvm
 // #cgo LDFLAGS: -L/usr/local/opt/llvm@9/lib -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM -lz -lcurses -lm -lxml2 -L/usr/local/opt/libffi/lib -lffi
 import "C"
 
-type (run_build_sh int)
+type run_build_sh int

--- a/llvm_config_linux.go
+++ b/llvm_config_linux.go
@@ -9,4 +9,4 @@ package llvm
 // #cgo LDFLAGS: -L/usr/lib/llvm-9/lib  -lLLVM-9
 import "C"
 
-type (run_build_sh int)
+type run_build_sh int

--- a/transforms_coroutines.go
+++ b/transforms_coroutines.go
@@ -17,7 +17,7 @@ package llvm
 */
 import "C"
 
-func (pm PassManager) AddCoroEarlyPass()      { C.LLVMAddCoroEarlyPass(pm.C) }
-func (pm PassManager) AddCoroSplitPass()      { C.LLVMAddCoroSplitPass(pm.C) }
-func (pm PassManager) AddCoroElidePass()      { C.LLVMAddCoroElidePass(pm.C) }
-func (pm PassManager) AddCoroCleanupPass()    { C.LLVMAddCoroCleanupPass(pm.C) }
+func (pm PassManager) AddCoroEarlyPass()   { C.LLVMAddCoroEarlyPass(pm.C) }
+func (pm PassManager) AddCoroSplitPass()   { C.LLVMAddCoroSplitPass(pm.C) }
+func (pm PassManager) AddCoroElidePass()   { C.LLVMAddCoroElidePass(pm.C) }
+func (pm PassManager) AddCoroCleanupPass() { C.LLVMAddCoroCleanupPass(pm.C) }


### PR DESCRIPTION
This syncs changes that were accepted into upstream LLVM, thus reducing the code in the backports files.

It is based on #12.