### PR TITLE
Add support to inject uint32 Module Flags

### DIFF
--- a/IRBindings.cpp
+++ b/IRBindings.cpp
@@ -25,6 +25,11 @@ LLVMMetadataRef LLVMConstantAsMetadata(LLVMValueRef C) {
   return wrap(ConstantAsMetadata::get(unwrap<Constant>(C)));
 }
 
+void LLVMAddModuleFlagUInt32(LLVMModuleRef M, LLVMContextRef C, const char *key, uint32_t val) {
+  Type *Int32Ty = Type::getInt32Ty(*unwrap(C));
+  unwrap(M)->addModuleFlag(Module::ModFlagBehavior::Error, key, ConstantInt::get(Int32Ty, val));
+}
+
 LLVMMetadataRef LLVMMDString2(LLVMContextRef C, const char *Str, unsigned SLen) {
   return wrap(MDString::get(*unwrap(C), StringRef(Str, SLen)));
 }

--- a/IRBindings.h
+++ b/IRBindings.h
@@ -49,6 +49,8 @@ void LLVMGoSetCurrentDebugLocation(LLVMBuilderRef Bref, unsigned Line,
 
 struct LLVMDebugLocMetadata LLVMGoGetCurrentDebugLocation(LLVMBuilderRef Bref);
 
+void LLVMAddModuleFlagUInt32(LLVMModuleRef M, LLVMContextRef C, const char *name, uint32_t val);
+
 #ifdef __cplusplus
 }
 

--- a/ir.go
+++ b/ir.go
@@ -508,6 +508,13 @@ func (m Module) AddNamedMetadataOperand(name string, operand Metadata) {
 	C.LLVMAddNamedMetadataOperand2(m.C, cname, operand.C)
 }
 
+func (m Module) AddModuleFlagUInt32(name string, value uint32) {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+
+	C.LLVMAddModuleFlagUInt32(m.C, m.Context().C, cname, C.uint(value))
+}
+
 func (m Module) Context() (c Context) {
 	c.C = C.LLVMGetModuleContext(m.C)
 	return


### PR DESCRIPTION
That enables the possibility to add module flags like `PIE Level` inside the LLVM module. 

I added this to add support to nintendo switch (which has ASLR) but so far I'm linking with GCC which does that with `-fPIE`. Still that's helpful to add several flags that can change the behaviour of code emitter.