### PR TITLE
add Context.ParseBitcodeFile

### DIFF
--- a/bitreader.go
+++ b/bitreader.go
@@ -48,3 +48,28 @@ func ParseBitcodeFile(name string) (Module, error) {
 	C.free(unsafe.Pointer(errmsg))
 	return Module{}, err
 }
+
+// ParseBitcodeFile parses the LLVM IR (bitcode) in the file with the specified
+// name, and returns a new LLVM module.
+func (c Context) ParseBitcodeFile(name string) (Module, error) {
+	var buf C.LLVMMemoryBufferRef
+	var errmsg *C.char
+	var cfilename *C.char = C.CString(name)
+	defer C.free(unsafe.Pointer(cfilename))
+	result := C.LLVMCreateMemoryBufferWithContentsOfFile(cfilename, &buf, &errmsg)
+	if result != 0 {
+		err := errors.New(C.GoString(errmsg))
+		C.free(unsafe.Pointer(errmsg))
+		return Module{}, err
+	}
+	defer C.LLVMDisposeMemoryBuffer(buf)
+
+	var m Module
+	if C.LLVMParseBitcodeInContext2(c.C, buf, &m.C) == 0 {
+		return m, nil
+	}
+
+	err := errors.New(C.GoString(errmsg))
+	C.free(unsafe.Pointer(errmsg))
+	return Module{}, err
+}


### PR DESCRIPTION
While there is a ParseBitcodeFile already, the resulting module lives in
the default context. This does not work when doing parallel builds.
Therefore, this extra function is needed to parse a bitcode file in a
different context.

---

This change is necessary for my work on parallelizing and caching compiled packages.