### PR TITLE
Add llvm version build tag to generated config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ help:
 	@echo "    LLVM sources root"
 
 config:
-	@echo "// +build !byollvm" > llvm_config_$(GOOS).go
-	@echo "// +build linux,llvm$(VERSION_MAJOR)" >> llvm_config_$(GOOS).go
+	@echo "//go:build !byollvm && linux && llvm$(VERSION_MAJOR)" > llvm_config_$(GOOS).go
+	@echo "// +build !byollvm,linux,llvm$(VERSION_MAJOR)" >> llvm_config_$(GOOS).go
 	@echo "" >> llvm_config_$(GOOS).go
 	@echo "package llvm" >> llvm_config_$(GOOS).go
 	@echo "" >> llvm_config_$(GOOS).go

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ help:
 
 config:
 	@echo "// +build !byollvm" > llvm_config_$(GOOS).go
+	@echo "// +build linux,llvm$(VERSION_MAJOR)" >> llvm_config_$(GOOS).go
 	@echo "" >> llvm_config_$(GOOS).go
 	@echo "package llvm" >> llvm_config_$(GOOS).go
 	@echo "" >> llvm_config_$(GOOS).go


### PR DESCRIPTION
Thus you can generate and copy it to `*_llvm{version}.go` directly without any editing.

With this, I can do `make config VERSION=${version} && mv llvm_config_linux.go llvm_config_linux_llvm${version}.go` multiple times, and test build against all supported LLVM easily.