### PR TITLE
fix tinygo build (llvm12 is explicit tag on go install)

### DIFF
--- a/llvm_config_linux.go
+++ b/llvm_config_linux.go
@@ -1,5 +1,5 @@
-//go:build !byollvm && linux && !llvm11
-// +build !byollvm,linux,!llvm11
+//go:build !byollvm && linux && !llvm11 && !llvm12
+// +build !byollvm,linux,!llvm11,!llvm12
 
 package llvm
 


### PR DESCRIPTION
Tinygo build does `go install -tags llvm12` which was broken by last change.  This change excludes `llvm_config_linux.go` when llvm12 tag is specified explicitly.