### PR TITLE
Add support for LLVM 14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,31 @@ jobs:
       - name: Test default LLVM
         run:
           go test -v
+  test-macos-llvm-14:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install LLVM
+        run: |
+          brew install llvm@14
+      - name: Test LLVM 14
+        run:
+          go test -v -tags=llvm14
+  test-linux-llvm-14:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install LLVM
+        run: |
+          echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main' | sudo tee /etc/apt/sources.list.d/llvm.list
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends llvm-14-dev
+      - name: Test LLVM 14
+        run:
+          go test -v -tags=llvm14
   test-linux-llvm-13:
     runs-on: ubuntu-20.04
     steps:

--- a/backports.cpp
+++ b/backports.cpp
@@ -3,6 +3,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Pass.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Transforms/IPO.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
@@ -75,4 +76,13 @@ LLVMMemoryBufferRef LLVMGoWriteThinLTOBitcodeToMemoryBuffer(LLVMModuleRef M) {
   PM.add(createWriteThinLTOBitcodePass(OS));
   PM.run(*llvm::unwrap(M));
   return llvm::wrap(llvm::MemoryBuffer::getMemBufferCopy(OS.str()).release());
+}
+
+LLVMMetadataRef LLVMGoDIBuilderCreateExpression(LLVMDIBuilderRef Builder,
+                                                uint64_t *Addr, size_t Length) {
+#if LLVM_VERSION_MAJOR >= 14
+  return LLVMDIBuilderCreateExpression(Builder, Addr, Length);
+#else
+  return LLVMDIBuilderCreateExpression(Builder, (int64_t*)Addr, Length);
+#endif
 }

--- a/backports.h
+++ b/backports.h
@@ -26,6 +26,8 @@ LLVMMetadataRef LLVMGoDIBuilderCreateCompileUnit(
     LLVMBool DebugInfoForProfiling, const char *SysRoot, size_t SysRootLen,
     const char *SDK, size_t SDKLen);
 
+LLVMMemoryBufferRef LLVMGoWriteThinLTOBitcodeToMemoryBuffer(LLVMModuleRef M);
+
 #ifdef __cplusplus
 }
 #endif /* defined(__cplusplus) */

--- a/backports.h
+++ b/backports.h
@@ -28,6 +28,9 @@ LLVMMetadataRef LLVMGoDIBuilderCreateCompileUnit(
 
 LLVMMemoryBufferRef LLVMGoWriteThinLTOBitcodeToMemoryBuffer(LLVMModuleRef M);
 
+LLVMMetadataRef LLVMGoDIBuilderCreateExpression(LLVMDIBuilderRef Builder,
+                                                uint64_t *Addr, size_t Length);
+
 #ifdef __cplusplus
 }
 #endif /* defined(__cplusplus) */

--- a/bitwriter.go
+++ b/bitwriter.go
@@ -14,6 +14,7 @@ package llvm
 
 /*
 #include "llvm-c/BitWriter.h"
+#include "backports.h"
 #include <stdlib.h>
 */
 import "C"
@@ -32,6 +33,11 @@ func WriteBitcodeToFile(m Module, file *os.File) error {
 
 func WriteBitcodeToMemoryBuffer(m Module) MemoryBuffer {
 	mb := C.LLVMWriteBitcodeToMemoryBuffer(m.C)
+	return MemoryBuffer{mb}
+}
+
+func WriteThinLTOBitcodeToMemoryBuffer(m Module) MemoryBuffer {
+	mb := C.LLVMGoWriteThinLTOBitcodeToMemoryBuffer(m.C)
 	return MemoryBuffer{mb}
 }
 

--- a/dibuilder.go
+++ b/dibuilder.go
@@ -601,12 +601,12 @@ func (d *DIBuilder) getOrCreateTypeArray(values []Metadata) Metadata {
 
 // CreateExpression creates a new descriptor for the specified
 // variable which has a complex address expression for its address.
-func (d *DIBuilder) CreateExpression(addr []int64) Metadata {
-	var data *C.int64_t
+func (d *DIBuilder) CreateExpression(addr []uint64) Metadata {
+	var data *C.uint64_t
 	if len(addr) > 0 {
-		data = (*C.int64_t)(unsafe.Pointer(&addr[0]))
+		data = (*C.uint64_t)(unsafe.Pointer(&addr[0]))
 	}
-	result := C.LLVMDIBuilderCreateExpression(d.ref, data, C.size_t(len(addr)))
+	result := C.LLVMGoDIBuilderCreateExpression(d.ref, data, C.size_t(len(addr)))
 	return Metadata{C: result}
 }
 

--- a/llvm_config_linux_llvm13.go
+++ b/llvm_config_linux_llvm13.go
@@ -1,5 +1,5 @@
-//go:build !byollvm && linux && !llvm11 && !llvm12
-// +build !byollvm,linux,!llvm11,!llvm12
+//go:build !byollvm && linux && !llvm11 && !llvm12 && !llvm14
+// +build !byollvm,linux,!llvm11,!llvm12,!llvm14
 
 package llvm
 

--- a/llvm_config_linux_llvm14.go
+++ b/llvm_config_linux_llvm14.go
@@ -1,0 +1,18 @@
+//go:build !byollvm && linux && llvm14
+// +build !byollvm,linux,llvm14
+
+package llvm
+
+// // Note: disabling deprecated warnings as a transition to new function
+// // signatures. We should fix this in LLVM 15 or so, when support for
+// // LLVM 13 is dropped and the old function signatures aren't supported
+// // anymore.
+// // Examples are: LLVMConstGEP2, LLVMAddAlias2, ...
+// #cgo CFLAGS: -Wno-deprecated-declarations
+//
+// #cgo CPPFLAGS: -I/usr/lib/llvm-14/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+// #cgo CXXFLAGS: -std=c++14
+// #cgo LDFLAGS: -L/usr/lib/llvm-14/lib  -lLLVM-14
+import "C"
+
+type run_build_sh int


### PR DESCRIPTION
This adds support for LLVM 14 on Linux. Unfortunately, LLVM 14 is not yet available in Homebrew so macOS support will have to wait a bit.

Note: I'm also working on TinyGo support for LLVM 14. It doesn't seem too difficult so far.