### PR TITLE
Fix misleading error message in analysis.go

### DIFF
--- a/analysis.go
+++ b/analysis.go
@@ -13,7 +13,7 @@
 package llvm
 
 /*
-#include "llvm-c/Analysis.h" // If you are getting an error here read bindings/go/README.txt
+#include "llvm-c/Analysis.h" // If you are getting an error here you need to build or install LLVM, see https://tinygo.org/docs/guides/build/
 #include "llvm-c/Core.h"
 #include <stdlib.h>
 */


### PR DESCRIPTION
The most likely reason why people are getting this error is when they haven't installed LLVM on their system (for example, from Homebrew).