### PR TITLE
Fix message disposal

### DIFF
--- a/ir.go
+++ b/ir.go
@@ -500,7 +500,7 @@ func (m Module) Dump() {
 
 func (m Module) String() string {
 	cir := C.LLVMPrintModuleToString(m.C)
-	defer C.free(unsafe.Pointer(cir))
+	defer C.LLVMDisposeMessage(cir)
 	ir := C.GoString(cir)
 	return ir
 }

--- a/irreader.go
+++ b/irreader.go
@@ -13,6 +13,7 @@
 package llvm
 
 /*
+#include "llvm-c/Core.h"
 #include "llvm-c/IRReader.h"
 #include <stdlib.h>
 */
@@ -20,7 +21,6 @@ import "C"
 
 import (
 	"errors"
-	"unsafe"
 )
 
 // ParseIR parses the textual IR given in the memory buffer and returns a new
@@ -30,7 +30,7 @@ func (c *Context) ParseIR(buf MemoryBuffer) (Module, error) {
 	var errmsg *C.char
 	if C.LLVMParseIRInContext(c.C, buf.C, &m.C, &errmsg) != 0 {
 		err := errors.New(C.GoString(errmsg))
-		C.free(unsafe.Pointer(errmsg))
+		C.LLVMDisposeMessage(errmsg)
 		return Module{}, err
 	}
 	return m, nil

--- a/target.go
+++ b/target.go
@@ -19,8 +19,10 @@ package llvm
 #include <stdlib.h>
 */
 import "C"
-import "unsafe"
-import "errors"
+import (
+	"errors"
+	"unsafe"
+)
 
 type (
 	TargetData struct {
@@ -220,7 +222,7 @@ func GetTargetFromTriple(triple string) (t Target, err error) {
 	fail := C.LLVMGetTargetFromTriple(ctriple, &t.C, &errstr)
 	if fail != 0 {
 		err = errors.New(C.GoString(errstr))
-		C.free(unsafe.Pointer(errstr))
+		C.LLVMDisposeMessage(errstr)
 	}
 	return
 }
@@ -264,6 +266,7 @@ func (tm TargetMachine) CreateTargetData() TargetData {
 // Triple returns the triple describing the machine (arch-vendor-os).
 func (tm TargetMachine) Triple() string {
 	cstr := C.LLVMGetTargetMachineTriple(tm.C)
+	defer C.LLVMDisposeMessage(cstr)
 	return C.GoString(cstr)
 }
 
@@ -290,7 +293,7 @@ func (tm TargetMachine) Dispose() {
 
 func DefaultTargetTriple() (triple string) {
 	cTriple := C.LLVMGetDefaultTargetTriple()
-	defer C.free(unsafe.Pointer(cTriple))
+	defer C.LLVMDisposeMessage(cTriple)
 	triple = C.GoString(cTriple)
 	return
 }


### PR DESCRIPTION
According to LLVM docs, these should be freed using their own function, not `free`.

I noticed this while looking at the docs for #45.