### PR TITLE
Add support for opaque pointers and structs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Install LLVM
         run: |
           brew update
+          brew install --overwrite python@3.11
           brew install llvm@16
       - name: Test LLVM 16
         run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,6 @@ jobs:
       - name: Install LLVM
         run: |
           brew update
-          brew install --overwrite python@3.11
           brew install llvm@16
       - name: Test LLVM 16
         run:

--- a/backports.cpp
+++ b/backports.cpp
@@ -48,3 +48,16 @@ LLVMMemoryBufferRef LLVMGoWriteThinLTOBitcodeToMemoryBuffer(LLVMModuleRef M) {
 #endif
   return llvm::wrap(llvm::MemoryBuffer::getMemBufferCopy(OS.str()).release());
 }
+
+#if LLVM_VERSION_MAJOR < 15
+
+// This is backported because version 14 supports opaque
+// pointers but I presume if you try to access the element
+// type it will crash. So this backport prevents that by
+// allowing to check if the pointer is opaque before trying
+// to access the element type.
+LLVMBool LLVMPointerTypeIsOpaque(LLVMTypeRef Ty) {
+  return llvm::unwrap<llvm::Type>(Ty)->isOpaquePointerTy();
+}
+
+#endif

--- a/backports.h
+++ b/backports.h
@@ -14,6 +14,19 @@ LLVMMemoryBufferRef LLVMGoWriteThinLTOBitcodeToMemoryBuffer(LLVMModuleRef M);
 LLVMMetadataRef LLVMGoDIBuilderCreateExpression(LLVMDIBuilderRef Builder,
                                                 uint64_t *Addr, size_t Length);
 
+#if LLVM_VERSION_MAJOR < 15
+/**
+ * Determine whether a pointer is opaque.
+ *
+ * True if this is an instance of an opaque PointerType.
+ *
+ * @see llvm::Type::isOpaquePointerTy()
+ */
+LLVMBool LLVMPointerTypeIsOpaque(LLVMTypeRef Ty);
+
+#endif
+
+
 #ifdef __cplusplus
 }
 #endif /* defined(__cplusplus) */

--- a/ir.go
+++ b/ir.go
@@ -16,6 +16,7 @@ package llvm
 #include "llvm-c/Core.h"
 #include "llvm-c/Comdat.h"
 #include "IRBindings.h"
+#include "backports.h"
 #include <stdlib.h>
 */
 import "C"

--- a/ir.go
+++ b/ir.go
@@ -711,10 +711,6 @@ func (t Type) IsPointerOpaque() bool { return C.LLVMPointerTypeIsOpaque(t.C) != 
 //
 // see llvm::SequentialType::getElementType()
 func (t Type) ElementType() (rt Type) {
-	if t.IsPointerOpaque() {
-		// avoid segfault
-		return Type{}
-	}
 	rt.C = C.LLVMGetElementType(t.C)
 	return
 }

--- a/ir.go
+++ b/ir.go
@@ -665,6 +665,7 @@ func (t Type) StructSetBody(elementTypes []Type, packed bool) {
 }
 
 func (t Type) IsStructPacked() bool         { return C.LLVMIsPackedStruct(t.C) != 0 }
+func (t Type) IsStructOpaque() bool         { return C.LLVMIsOpaqueStruct(t.C) != 0 }
 func (t Type) StructElementTypesCount() int { return int(C.LLVMCountStructElementTypes(t.C)) }
 func (t Type) StructElementTypes() []Type {
 	out := make([]Type, t.StructElementTypesCount())
@@ -676,7 +677,12 @@ func (t Type) StructElementTypes() []Type {
 
 // Operations on array, pointer, and vector types (sequence types)
 func (t Type) Subtypes() (ret []Type) {
-	ret = make([]Type, C.LLVMGetNumContainedTypes(t.C))
+	num := C.LLVMGetNumContainedTypes(t.C)
+	if num == 0 {
+		// prevent a crash at &ret[0] if there are no subtypes
+		return nil
+	}
+	ret = make([]Type, num)
 	C.LLVMGetSubtypes(t.C, llvmTypeRefPtr(&ret[0]))
 	return
 }
@@ -694,6 +700,7 @@ func VectorType(elementType Type, elementCount int) (t Type) {
 	return
 }
 
+func (t Type) IsPointerOpaque() bool    { return C.LLVMPointerTypeIsOpaque(t.C) != 0 }
 func (t Type) ElementType() (rt Type)   { rt.C = C.LLVMGetElementType(t.C); return }
 func (t Type) ArrayLength() int         { return int(C.LLVMGetArrayLength(t.C)) }
 func (t Type) PointerAddressSpace() int { return int(C.LLVMGetPointerAddressSpace(t.C)) }


### PR DESCRIPTION
If you call `ElementType()` on an opaque pointer, it causes a segfault. Unfortunately there was no way to know you had an opaque pointer on your hands before this change, so there was no way to know that calling `ElementType()` on the type that was a `PointerTypeKind` would crash.

This change introduces a `IsPointerOpaque()` method to check for opaque pointers. While I was at it, I noticed there was no way to check for opaque structs as well, so I added that. I also tried calling `Subtypes()` and noticed it causes an index out of range panic when there is no subtypes, so I fixed that too.

When I uploaded the fix, I noticed that LLVM 14 doesn't have the method to check for opaque pointers, which is odd because opaque pointers have been a thing since 2015.... at any rate, it was simple enough to add a back port for it, though it took a couple tries to get the CI to pass.