### PR TITLE
Remove functions/methods that work on the global context

### DIFF
--- a/bitreader.go
+++ b/bitreader.go
@@ -24,31 +24,6 @@ import (
 	"unsafe"
 )
 
-// ParseBitcodeFile parses the LLVM IR (bitcode) in the file with the
-// specified name, and returns a new LLVM module.
-func ParseBitcodeFile(name string) (Module, error) {
-	var buf C.LLVMMemoryBufferRef
-	var errmsg *C.char
-	var cfilename *C.char = C.CString(name)
-	defer C.free(unsafe.Pointer(cfilename))
-	result := C.LLVMCreateMemoryBufferWithContentsOfFile(cfilename, &buf, &errmsg)
-	if result != 0 {
-		err := errors.New(C.GoString(errmsg))
-		C.free(unsafe.Pointer(errmsg))
-		return Module{}, err
-	}
-	defer C.LLVMDisposeMemoryBuffer(buf)
-
-	var m Module
-	if C.LLVMParseBitcode2(buf, &m.C) == 0 {
-		return m, nil
-	}
-
-	err := errors.New(C.GoString(errmsg))
-	C.free(unsafe.Pointer(errmsg))
-	return Module{}, err
-}
-
 // ParseBitcodeFile parses the LLVM IR (bitcode) in the file with the specified
 // name, and returns a new LLVM module.
 func (c Context) ParseBitcodeFile(name string) (Module, error) {

--- a/ir.go
+++ b/ir.go
@@ -448,13 +448,6 @@ func (a Attribute) IsString() bool {
 
 // Create and destroy modules.
 // See llvm::Module::Module.
-func NewModule(name string) (m Module) {
-	cname := C.CString(name)
-	defer C.free(unsafe.Pointer(cname))
-	m.C = C.LLVMModuleCreateWithName(cname)
-	return
-}
-
 func (c Context) NewModule(name string) (m Module) {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
@@ -563,17 +556,6 @@ func (c Context) IntType(numbits int) (t Type) {
 	return
 }
 
-func Int1Type() (t Type)  { t.C = C.LLVMInt1Type(); return }
-func Int8Type() (t Type)  { t.C = C.LLVMInt8Type(); return }
-func Int16Type() (t Type) { t.C = C.LLVMInt16Type(); return }
-func Int32Type() (t Type) { t.C = C.LLVMInt32Type(); return }
-func Int64Type() (t Type) { t.C = C.LLVMInt64Type(); return }
-
-func IntType(numbits int) (t Type) {
-	t.C = C.LLVMIntType(C.unsigned(numbits))
-	return
-}
-
 func (t Type) IntTypeWidth() int {
 	return int(C.LLVMGetIntTypeWidth(t.C))
 }
@@ -584,12 +566,6 @@ func (c Context) DoubleType() (t Type)   { t.C = C.LLVMDoubleTypeInContext(c.C);
 func (c Context) X86FP80Type() (t Type)  { t.C = C.LLVMX86FP80TypeInContext(c.C); return }
 func (c Context) FP128Type() (t Type)    { t.C = C.LLVMFP128TypeInContext(c.C); return }
 func (c Context) PPCFP128Type() (t Type) { t.C = C.LLVMPPCFP128TypeInContext(c.C); return }
-
-func FloatType() (t Type)    { t.C = C.LLVMFloatType(); return }
-func DoubleType() (t Type)   { t.C = C.LLVMDoubleType(); return }
-func X86FP80Type() (t Type)  { t.C = C.LLVMX86FP80Type(); return }
-func FP128Type() (t Type)    { t.C = C.LLVMFP128Type(); return }
-func PPCFP128Type() (t Type) { t.C = C.LLVMPPCFP128Type(); return }
 
 // Operations on function types
 func FunctionType(returnType Type, paramTypes []Type, isVarArg bool) (t Type) {
@@ -705,9 +681,6 @@ func (t Type) VectorSize() int          { return int(C.LLVMGetVectorSize(t.C)) }
 func (c Context) VoidType() (t Type)  { t.C = C.LLVMVoidTypeInContext(c.C); return }
 func (c Context) LabelType() (t Type) { t.C = C.LLVMLabelTypeInContext(c.C); return }
 func (c Context) TokenType() (t Type) { t.C = C.LLVMTokenTypeInContext(c.C); return }
-
-func VoidType() (t Type)  { t.C = C.LLVMVoidType(); return }
-func LabelType() (t Type) { t.C = C.LLVMLabelType(); return }
 
 //-------------------------------------------------------------------------
 // llvm.Value
@@ -1363,7 +1336,6 @@ func (v Value) AllocatedType() (t Type) { t.C = C.LLVMGetAllocatedType(v.C); ret
 // exclusive means of building instructions using the C interface.
 
 func (c Context) NewBuilder() (b Builder) { b.C = C.LLVMCreateBuilderInContext(c.C); return }
-func NewBuilder() (b Builder)             { b.C = C.LLVMCreateBuilder(); return }
 func (b Builder) SetInsertPoint(block BasicBlock, instr Value) {
 	C.LLVMPositionBuilder(b.C, block.C, instr.C)
 }
@@ -1402,7 +1374,7 @@ func (b Builder) GetCurrentDebugLocation() (loc DebugLoc) {
 func (b Builder) SetInstDebugLocation(v Value) { C.LLVMSetInstDebugLocation(b.C, v.C) }
 func (b Builder) InsertDeclare(module Module, storage Value, md Value) Value {
 	f := module.NamedFunction("llvm.dbg.declare")
-	ftyp := FunctionType(VoidType(), []Type{storage.Type(), md.Type()}, false)
+	ftyp := FunctionType(module.Context().VoidType(), []Type{storage.Type(), md.Type()}, false)
 	if f.IsNil() {
 		f = AddFunction(module, "llvm.dbg.declare", ftyp)
 	}

--- a/ir_test.go
+++ b/ir_test.go
@@ -19,10 +19,11 @@ import (
 )
 
 func testAttribute(t *testing.T, name string) {
-	mod := NewModule("")
+	ctx := NewContext()
+	mod := ctx.NewModule("")
 	defer mod.Dispose()
 
-	ftyp := FunctionType(VoidType(), nil, false)
+	ftyp := FunctionType(ctx.VoidType(), nil, false)
 	fn := AddFunction(mod, "foo", ftyp)
 
 	kind := AttributeKindID(name)
@@ -104,10 +105,9 @@ func TestAttributes(t *testing.T) {
 }
 
 func TestDebugLoc(t *testing.T) {
-	mod := NewModule("")
+	ctx := NewContext()
+	mod := ctx.NewModule("")
 	defer mod.Dispose()
-
-	ctx := mod.Context()
 
 	b := ctx.NewBuilder()
 	defer b.Dispose()


### PR DESCRIPTION
The global context should almost never be used, but it's very easy to use accidentally. Therefore, I'd like to remove all convenience functions that use the global context.

All functionality that got removed is still accessible as methods on llvm.Context, and the global context can be obtained using llvm.GlobalContext(). So no actual functionality is lost, just the very easy to misuse "convenience" functions.

@rj45 any opinion on this? Because I suspect you're the only other user of this package and this is a breaking API change.