### PR TITLE
CI: update actions/checkout to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         llvm: [14, 15, 16, 17]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Update Homebrew
         if: matrix.llvm == 17 # needed as long as LLVM 17 is still fresh
         run: brew update
@@ -33,7 +33,7 @@ jobs:
         llvm: [14, 15, 16, 17]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install LLVM
         run: |
           echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${{ matrix.llvm }} main' | sudo tee /etc/apt/sources.list.d/llvm.list


### PR DESCRIPTION
Update GH workflow `test` with `actions/checkout` version 4

Old version 2 of this action uses Node12, now deprecated => see https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/