### PR TITLE
build: add GH action to install Go

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
       - name: Update Homebrew
         if: matrix.llvm == 17 # needed as long as LLVM 17 is still fresh
         run: brew update
@@ -34,6 +38,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
       - name: Install LLVM
         run: |
           echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${{ matrix.llvm }} main' | sudo tee /etc/apt/sources.list.d/llvm.list


### PR DESCRIPTION
This PR is to update the GH actions to install Go before running the normal tests.