### PR TITLE
add freebsd support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,3 +55,32 @@ jobs:
         if: matrix.llvm == 21
         run:
           go test -v
+  test-freebsd:
+    name: test-freebsd
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        llvm: [19, 20]
+    steps:
+    - uses: actions/checkout@v4
+    - name: FreeBSD test 14.3
+      uses: vmactions/freebsd-vm@v1
+      with:
+        release: '14.3'
+        usesh: true
+        prepare: |
+          # Update package database with IGNORE_OSVERSION
+          pkg update -f || true
+          # Install llvm build dependencies
+          pkg install -y llvm${{ matrix.llvm }}
+          # Install default version go dependency
+          pkg install -y go
+        run: |
+          # Show environment info
+          echo "FreeBSD version:"
+          freebsd-version
+          # Test with llvm${{ matrix.llvm }}
+          echo "Clang ${{ matrix.llvm }} version info:"
+          /usr/local/llvm${{ matrix.llvm }}/bin/clang --version
+          echo "Test with llvm${{ matrix.llvm }} tag"
+          go test -v -tags=llvm${{ matrix.llvm }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,32 +55,3 @@ jobs:
         if: matrix.llvm == 21
         run:
           go test -v
-  test-freebsd:
-    name: test-freebsd
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        llvm: [19, 20]
-    steps:
-    - uses: actions/checkout@v4
-    - name: FreeBSD test 14.3
-      uses: vmactions/freebsd-vm@v1
-      with:
-        release: '14.3'
-        usesh: true
-        prepare: |
-          # Update package database with IGNORE_OSVERSION
-          pkg update -f || true
-          # Install llvm build dependencies
-          pkg install -y llvm${{ matrix.llvm }}
-          # Install default version go dependency
-          pkg install -y go
-        run: |
-          # Show environment info
-          echo "FreeBSD version:"
-          freebsd-version
-          # Test with llvm${{ matrix.llvm }}
-          echo "Clang ${{ matrix.llvm }} version info:"
-          /usr/local/llvm${{ matrix.llvm }}/bin/clang --version
-          echo "Test with llvm${{ matrix.llvm }} tag"
-          go test -v -tags=llvm${{ matrix.llvm }}

--- a/llvm_config_llvm19.go
+++ b/llvm_config_llvm19.go
@@ -8,9 +8,9 @@ package llvm
 // #cgo darwin,arm64 CPPFLAGS: -I/opt/homebrew/opt/llvm@19/include   -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
 // #cgo darwin,arm64 CXXFLAGS: -std=c++17
 // #cgo darwin,arm64 LDFLAGS: -L/opt/homebrew/opt/llvm@19/lib -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM -lz -lm
-// #cgo freebsd CPPFLAGS: -I/usr/local/llvm19/include -I/usr/local/llvm19/include/llvm-c -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-// #cgo freebsd CXXFLAGS: -std=c++17
-// #cgo freebsd LDFLAGS: -L/usr/local/llvm19/lib -lLLVM
+// #cgo freebsd      CPPFLAGS: -I/usr/local/llvm19/include -I/usr/local/llvm19/include/llvm-c -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+// #cgo freebsd      CXXFLAGS: -std=c++17
+// #cgo freebsd      LDFLAGS: -L/usr/local/llvm19/lib -lLLVM
 // #cgo linux        CPPFLAGS: -I/usr/include/llvm-19 -I/usr/include/llvm-c-19 -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
 // #cgo linux        CXXFLAGS: -std=c++17
 // #cgo linux        LDFLAGS: -L/usr/lib/llvm-19/lib -lLLVM-19

--- a/llvm_config_llvm19.go
+++ b/llvm_config_llvm19.go
@@ -8,6 +8,9 @@ package llvm
 // #cgo darwin,arm64 CPPFLAGS: -I/opt/homebrew/opt/llvm@19/include   -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
 // #cgo darwin,arm64 CXXFLAGS: -std=c++17
 // #cgo darwin,arm64 LDFLAGS: -L/opt/homebrew/opt/llvm@19/lib -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM -lz -lm
+// #cgo freebsd CPPFLAGS: -I/usr/local/llvm19/include -I/usr/local/llvm19/include/llvm-c -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+// #cgo freebsd CXXFLAGS: -std=c++17
+// #cgo freebsd LDFLAGS: -L/usr/local/llvm19/lib -lLLVM
 // #cgo linux        CPPFLAGS: -I/usr/include/llvm-19 -I/usr/include/llvm-c-19 -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
 // #cgo linux        CXXFLAGS: -std=c++17
 // #cgo linux        LDFLAGS: -L/usr/lib/llvm-19/lib -lLLVM-19

--- a/llvm_config_llvm20.go
+++ b/llvm_config_llvm20.go
@@ -8,6 +8,9 @@ package llvm
 // #cgo darwin,arm64 CPPFLAGS: -I/opt/homebrew/opt/llvm@20/include   -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
 // #cgo darwin,arm64 CXXFLAGS: -std=c++17
 // #cgo darwin,arm64 LDFLAGS: -L/opt/homebrew/opt/llvm@20/lib -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM -lz -lm
+// #cgo freebsd CPPFLAGS: -I/usr/local/llvm20/include -I/usr/local/llvm20/include/llvm-c -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+// #cgo freebsd CXXFLAGS: -std=c++17
+// #cgo freebsd LDFLAGS: -L/usr/local/llvm20/lib -lLLVM
 // #cgo linux        CPPFLAGS: -I/usr/include/llvm-20 -I/usr/include/llvm-c-20 -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
 // #cgo linux        CXXFLAGS: -std=c++17
 // #cgo linux        LDFLAGS: -L/usr/lib/llvm-20/lib -lLLVM-20

--- a/llvm_config_llvm20.go
+++ b/llvm_config_llvm20.go
@@ -8,9 +8,9 @@ package llvm
 // #cgo darwin,arm64 CPPFLAGS: -I/opt/homebrew/opt/llvm@20/include   -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
 // #cgo darwin,arm64 CXXFLAGS: -std=c++17
 // #cgo darwin,arm64 LDFLAGS: -L/opt/homebrew/opt/llvm@20/lib -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM -lz -lm
-// #cgo freebsd CPPFLAGS: -I/usr/local/llvm20/include -I/usr/local/llvm20/include/llvm-c -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-// #cgo freebsd CXXFLAGS: -std=c++17
-// #cgo freebsd LDFLAGS: -L/usr/local/llvm20/lib -lLLVM
+// #cgo freebsd      CPPFLAGS: -I/usr/local/llvm20/include -I/usr/local/llvm20/include/llvm-c -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+// #cgo freebsd      CXXFLAGS: -std=c++17
+// #cgo freebsd      LDFLAGS: -L/usr/local/llvm20/lib -lLLVM
 // #cgo linux        CPPFLAGS: -I/usr/include/llvm-20 -I/usr/include/llvm-c-20 -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
 // #cgo linux        CXXFLAGS: -std=c++17
 // #cgo linux        LDFLAGS: -L/usr/lib/llvm-20/lib -lLLVM-20

--- a/llvm_config_llvm21.go
+++ b/llvm_config_llvm21.go
@@ -8,6 +8,9 @@ package llvm
 // #cgo darwin,arm64 CPPFLAGS: -I/opt/homebrew/opt/llvm@21/include   -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
 // #cgo darwin,arm64 CXXFLAGS: -std=c++17
 // #cgo darwin,arm64 LDFLAGS: -L/opt/homebrew/opt/llvm@21/lib -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM -lz -lm
+// #cgo freebsd CPPFLAGS: -I/usr/local/llvm21/include -I/usr/local/llvm21/include/llvm-c -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+// #cgo freebsd CXXFLAGS: -std=c++17
+// #cgo freebsd LDFLAGS: -L/usr/local/llvm21/lib -lLLVM
 // #cgo linux        CPPFLAGS: -I/usr/include/llvm-21 -I/usr/include/llvm-c-21 -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
 // #cgo linux        CXXFLAGS: -std=c++17
 // #cgo linux        LDFLAGS: -L/usr/lib/llvm-21/lib -lLLVM-21

--- a/llvm_config_llvm21.go
+++ b/llvm_config_llvm21.go
@@ -8,9 +8,9 @@ package llvm
 // #cgo darwin,arm64 CPPFLAGS: -I/opt/homebrew/opt/llvm@21/include   -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
 // #cgo darwin,arm64 CXXFLAGS: -std=c++17
 // #cgo darwin,arm64 LDFLAGS: -L/opt/homebrew/opt/llvm@21/lib -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM -lz -lm
-// #cgo freebsd CPPFLAGS: -I/usr/local/llvm21/include -I/usr/local/llvm21/include/llvm-c -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-// #cgo freebsd CXXFLAGS: -std=c++17
-// #cgo freebsd LDFLAGS: -L/usr/local/llvm21/lib -lLLVM
+// #cgo freebsd      CPPFLAGS: -I/usr/local/llvm21/include -I/usr/local/llvm21/include/llvm-c -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+// #cgo freebsd      CXXFLAGS: -std=c++17
+// #cgo freebsd      LDFLAGS: -L/usr/local/llvm21/lib -lLLVM
 // #cgo linux        CPPFLAGS: -I/usr/include/llvm-21 -I/usr/include/llvm-c-21 -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
 // #cgo linux        CXXFLAGS: -std=c++17
 // #cgo linux        LDFLAGS: -L/usr/lib/llvm-21/lib -lLLVM-21


### PR DESCRIPTION
the following changeset allows go-llvm (as well as tinygo) to compile on freebsd (tested on freebsd 14.3). without the changes applied the following error occurs when trying to compile on freebsd

```
$ uname -a
FreeBSD quincy 14.3-RELEASE FreeBSD 14.3-RELEASE releng/14.3-n271432-8c9ce319fef7 GENERIC amd64

$ go build ./...
# tinygo.org/x/go-llvm
./bitwriter.go:16:10: fatal error: 'llvm-c/BitWriter.h' file not found
   16 | #include "llvm-c/BitWriter.h"
      |          ^~~~~
``` 