### PR TITLE
Add paths for older LLVM versions on Fedora

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,3 +55,26 @@ jobs:
         if: matrix.llvm == 21
         run:
           go test -v
+  test-linux-fedora:
+    # Fedora uses different paths than other systems, so testing it separately.
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        llvm: [19, 20, 21]
+    container: fedora:43
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies (default LLVM)
+        if: matrix.llvm == 21
+        run: dnf install --assumeyes g++ golang llvm-devel
+      - name: Install dependencies (older LLVM)
+        if: matrix.llvm != 21
+        run: dnf install --assumeyes g++ golang llvm${{ matrix.llvm }}-devel
+      - name: Test LLVM ${{ matrix.llvm }}
+        run:
+          go test -v -tags=llvm${{ matrix.llvm }}
+      - name: Test default LLVM
+        if: matrix.llvm == 21
+        run:
+          go test -v

--- a/llvm_config_llvm19.go
+++ b/llvm_config_llvm19.go
@@ -11,9 +11,9 @@ package llvm
 // #cgo freebsd      CPPFLAGS: -I/usr/local/llvm19/include -I/usr/local/llvm19/include/llvm-c -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
 // #cgo freebsd      CXXFLAGS: -std=c++17
 // #cgo freebsd      LDFLAGS: -L/usr/local/llvm19/lib -lLLVM
-// #cgo linux        CPPFLAGS: -I/usr/include/llvm-19 -I/usr/include/llvm-c-19 -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+// #cgo linux        CPPFLAGS: -I/usr/include/llvm-19 -I/usr/include/llvm-c-19 -I/usr/lib64/llvm19/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
 // #cgo linux        CXXFLAGS: -std=c++17
-// #cgo linux        LDFLAGS: -L/usr/lib/llvm-19/lib -lLLVM-19
+// #cgo linux        LDFLAGS: -L/usr/lib/llvm-19/lib -L/usr/lib64/llvm19/lib -lLLVM-19
 import "C"
 
 type run_build_sh int

--- a/llvm_config_llvm20.go
+++ b/llvm_config_llvm20.go
@@ -11,9 +11,9 @@ package llvm
 // #cgo freebsd      CPPFLAGS: -I/usr/local/llvm20/include -I/usr/local/llvm20/include/llvm-c -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
 // #cgo freebsd      CXXFLAGS: -std=c++17
 // #cgo freebsd      LDFLAGS: -L/usr/local/llvm20/lib -lLLVM
-// #cgo linux        CPPFLAGS: -I/usr/include/llvm-20 -I/usr/include/llvm-c-20 -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+// #cgo linux        CPPFLAGS: -I/usr/include/llvm-20 -I/usr/include/llvm-c-20 -I/usr/lib64/llvm20/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
 // #cgo linux        CXXFLAGS: -std=c++17
-// #cgo linux        LDFLAGS: -L/usr/lib/llvm-20/lib -lLLVM-20
+// #cgo linux        LDFLAGS: -L/usr/lib/llvm-20/lib -L/usr/lib64/llvm20/lib64 -lLLVM-20
 import "C"
 
 type run_build_sh int


### PR DESCRIPTION
This makes  my life slightly easier on Fedora 43, as long as we don't have LLVM 21 support in TinyGo.