### PR TITLE
Use LLVM 20 by default for now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         run:
           go test -v -tags=llvm${{ matrix.llvm }}
       - name: Test default LLVM
-        if: matrix.llvm == 21
+        if: matrix.llvm == 20
         run:
           go test -v
   test-linux:
@@ -52,7 +52,7 @@ jobs:
         run:
           go test -v -tags=llvm${{ matrix.llvm }}
       - name: Test default LLVM
-        if: matrix.llvm == 21
+        if: matrix.llvm == 20
         run:
           go test -v
   test-linux-fedora:
@@ -75,6 +75,6 @@ jobs:
         run:
           go test -v -tags=llvm${{ matrix.llvm }}
       - name: Test default LLVM
-        if: matrix.llvm == 21
+        if: matrix.llvm == 20
         run:
           go test -v

--- a/llvm_config_llvm20.go
+++ b/llvm_config_llvm20.go
@@ -1,4 +1,4 @@
-//go:build !byollvm && llvm20
+//go:build !byollvm && !llvm14 && !llvm15 && !llvm16 && !llvm17 && !llvm18 && !llvm19 && !llvm21
 
 package llvm
 

--- a/llvm_config_llvm21.go
+++ b/llvm_config_llvm21.go
@@ -1,4 +1,4 @@
-//go:build !byollvm && !llvm14 && !llvm15 && !llvm16 && !llvm17 && !llvm18 && !llvm19 && !llvm20
+//go:build !byollvm && llvm21
 
 package llvm
 


### PR DESCRIPTION
We still haven't updated TinyGo, so this change is needed so we can use https://github.com/tinygo-org/go-llvm/pull/73 in TinyGo. See: https://github.com/tinygo-org/tinygo/pull/5333 (currently fails in CI because of the mismatched default LLVM version).