### PR TITLE
go-llvm: use context-aware LLVM C APIs for functions deprecated in LLVM 22

### DIFF
--- a/deprecated.c
+++ b/deprecated.c
@@ -1,0 +1,24 @@
+//===- deprecated.c - Wrappers for deprecated LLVM C API --------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file wraps LLVMGetGlobalContext, which was deprecated in LLVM 22 but
+// has no non-deprecated replacement. All other wrapped functions are
+// handled by calling their context-aware counterparts from Go.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+#include "deprecated.h"
+
+LLVMContextRef LLVMGetGlobalContext_wrap(void) {
+  return LLVMGetGlobalContext();
+}
+
+#pragma GCC diagnostic pop

--- a/deprecated.h
+++ b/deprecated.h
@@ -1,0 +1,30 @@
+//===- deprecated.h - Wrappers for deprecated LLVM C API --------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file wraps LLVMGetGlobalContext, which was deprecated in LLVM 22 but
+// has no non-deprecated replacement. All other wrapped functions are
+// handled by calling their context-aware counterparts from Go.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_BINDINGS_GO_LLVM_DEPRECATED_H
+#define LLVM_BINDINGS_GO_LLVM_DEPRECATED_H
+
+#include "llvm-c/Core.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+LLVMContextRef LLVMGetGlobalContext_wrap(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // LLVM_BINDINGS_GO_LLVM_DEPRECATED_H

--- a/ir.go
+++ b/ir.go
@@ -16,6 +16,7 @@ package llvm
 #include "llvm-c/Core.h"
 #include "llvm-c/Comdat.h"
 #include "IRBindings.h"
+#include "deprecated.h"
 #include <stdlib.h>
 */
 import "C"
@@ -357,7 +358,7 @@ const (
 //-------------------------------------------------------------------------
 
 func NewContext() Context    { return Context{C.LLVMContextCreate()} }
-func GlobalContext() Context { return Context{C.LLVMGetGlobalContext()} }
+func GlobalContext() Context { return Context{C.LLVMGetGlobalContext_wrap()} }
 func (c Context) Dispose()   { C.LLVMContextDispose(c.C) }
 
 func (c Context) MDKindID(name string) (id int) {
@@ -368,10 +369,7 @@ func (c Context) MDKindID(name string) (id int) {
 }
 
 func MDKindID(name string) (id int) {
-	cname := C.CString(name)
-	defer C.free(unsafe.Pointer(cname))
-	id = int(C.LLVMGetMDKindID(cname, C.unsigned(len(name))))
-	return
+	return GlobalContext().MDKindID(name)
 }
 
 //-------------------------------------------------------------------------
@@ -610,14 +608,7 @@ func (c Context) StructType(elementTypes []Type, packed bool) (t Type) {
 }
 
 func StructType(elementTypes []Type, packed bool) (t Type) {
-	var pt *C.LLVMTypeRef
-	var ptlen C.unsigned
-	if len(elementTypes) > 0 {
-		pt = llvmTypeRefPtr(&elementTypes[0])
-		ptlen = C.unsigned(len(elementTypes))
-	}
-	t.C = C.LLVMStructType(pt, ptlen, boolToLLVMBool(packed))
-	return
+	return GlobalContext().StructType(elementTypes, packed)
 }
 
 func (c Context) StructCreateNamed(name string) (t Type) {
@@ -882,11 +873,7 @@ func ConstNamedStruct(t Type, constVals []Value) (v Value) {
 	return
 }
 func ConstString(str string, addnull bool) (v Value) {
-	cstr := C.CString(str)
-	defer C.free(unsafe.Pointer(cstr))
-	v.C = C.LLVMConstString(cstr,
-		C.unsigned(len(str)), boolToLLVMBool(!addnull))
-	return
+	return GlobalContext().ConstString(str, addnull)
 }
 func ConstArray(t Type, constVals []Value) (v Value) {
 	ptr, nvals := llvmValueRefs(constVals)
@@ -894,9 +881,7 @@ func ConstArray(t Type, constVals []Value) (v Value) {
 	return
 }
 func ConstStruct(constVals []Value, packed bool) (v Value) {
-	ptr, nvals := llvmValueRefs(constVals)
-	v.C = C.LLVMConstStruct(ptr, nvals, boolToLLVMBool(packed))
-	return
+	return GlobalContext().ConstStruct(constVals, packed)
 }
 func ConstVector(scalarConstVals []Value, packed bool) (v Value) {
 	ptr, nvals := llvmValueRefs(scalarConstVals)
@@ -1203,16 +1188,10 @@ func (c Context) InsertBasicBlock(ref BasicBlock, name string) (bb BasicBlock) {
 	return
 }
 func AddBasicBlock(f Value, name string) (bb BasicBlock) {
-	cname := C.CString(name)
-	defer C.free(unsafe.Pointer(cname))
-	bb.C = C.LLVMAppendBasicBlock(f.C, cname)
-	return
+	return GlobalContext().AddBasicBlock(f, name)
 }
 func InsertBasicBlock(ref BasicBlock, name string) (bb BasicBlock) {
-	cname := C.CString(name)
-	defer C.free(unsafe.Pointer(cname))
-	bb.C = C.LLVMInsertBasicBlock(ref.C, cname)
-	return
+	return GlobalContext().InsertBasicBlock(ref, name)
 }
 func (bb BasicBlock) EraseFromParent()          { C.LLVMDeleteBasicBlock(bb.C) }
 func (bb BasicBlock) MoveBefore(pos BasicBlock) { C.LLVMMoveBasicBlockBefore(bb.C, pos.C) }

--- a/target.go
+++ b/target.go
@@ -16,6 +16,7 @@ package llvm
 #include "llvm-c/Core.h"
 #include "llvm-c/Target.h"
 #include "llvm-c/TargetMachine.h"
+#include "deprecated.h"
 #include <stdlib.h>
 */
 import "C"
@@ -143,7 +144,10 @@ func (td TargetData) PointerSize() int { return int(C.LLVMPointerSize(td.C)) }
 
 // Returns the integer type that is the same size as a pointer on a target.
 // See the method llvm::TargetData::getIntPtrType.
-func (td TargetData) IntPtrType() (t Type) { t.C = C.LLVMIntPtrType(td.C); return }
+func (td TargetData) IntPtrType() (t Type) {
+	t.C = C.LLVMIntPtrTypeInContext(C.LLVMGetGlobalContext_wrap(), td.C)
+	return
+}
 
 // Computes the size of a type in bytes for a target.
 // See the method llvm::TargetData::getTypeSizeInBits.


### PR DESCRIPTION
LLVM 22 deprecated 8 global-context C API functions in favor of their
context-aware counterparts. Instead of suppressing the warnings, call
the non-deprecated InContext APIs directly.

The non-context Go functions (MDKindID, StructType, ConstString,
ConstStruct, AddBasicBlock, InsertBasicBlock) now delegate to
GlobalContext().<method>(), which already calls the InContext C APIs.
IntPtrType calls LLVMIntPtrTypeInContext directly.

Only LLVMGetGlobalContext still needs a warning-suppression wrapper
in deprecated.c since it has no non-deprecated replacement.

The context-aware C APIs have been available since well before LLVM 14,
so this works across all supported LLVM versions.

Here is an example:

```
# tinygo.org/x/go-llvm
cgo-gcc-prolog: In function ‘_cgo_2ad2ad839789_Cfunc_LLVMIntPtrType’:
cgo-gcc-prolog:477:2: warning: ‘LLVMIntPtrType’ is deprecated [-Wdeprecated-declarations]
In file included from ../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Core.h:18,
                 from ../../../go/pkg/mod/tinygo.org/x/go-llvm@v0.0.0-20260707200325-ddd595b68360/target.go:16:
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Target.h:234:41: note: declared here
  234 | LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMIntPtrType(LLVMTargetDataRef TD),
      |                                         ^~~~~~~~~~~~~~
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Deprecated.h:29:3: note: in definition of macro ‘LLVM_ATTRIBUTE_C_DEPRECATED’
   29 |   decl __attribute__((deprecated))
      |   ^~~~
# tinygo.org/x/go-llvm
cgo-gcc-prolog: In function ‘_cgo_2ad2ad839789_Cfunc_LLVMAppendBasicBlock’:
cgo-gcc-prolog:285:2: warning: ‘LLVMAppendBasicBlock’ is deprecated [-Wdeprecated-declarations]
In file included from ../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Core.h:18,
                 from ../../../go/pkg/mod/tinygo.org/x/go-llvm@v0.0.0-20260707200325-ddd595b68360/ir.go:16:
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Core.h:3717:23: note: declared here
 3717 |     LLVMBasicBlockRef LLVMAppendBasicBlock(LLVMValueRef Fn, const char *Name),
      |                       ^~~~~~~~~~~~~~~~~~~~
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Deprecated.h:29:3: note: in definition of macro ‘LLVM_ATTRIBUTE_C_DEPRECATED’
   29 |   decl __attribute__((deprecated))
      |   ^~~~
cgo-gcc-prolog: In function ‘_cgo_2ad2ad839789_Cfunc_LLVMConstString’:
cgo-gcc-prolog:2925:2: warning: ‘LLVMConstString’ is deprecated [-Wdeprecated-declarations]
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Core.h:2489:18: note: declared here
 2489 |     LLVMValueRef LLVMConstString(const char *Str, unsigned Length,
      |                  ^~~~~~~~~~~~~~~
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Deprecated.h:29:3: note: in definition of macro ‘LLVM_ATTRIBUTE_C_DEPRECATED’
   29 |   decl __attribute__((deprecated))
      |   ^~~~
cgo-gcc-prolog: In function ‘_cgo_2ad2ad839789_Cfunc_LLVMConstStruct’:
cgo-gcc-prolog:2966:2: warning: ‘LLVMConstStruct’ is deprecated [-Wdeprecated-declarations]
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Core.h:2538:18: note: declared here
 2538 |     LLVMValueRef LLVMConstStruct(LLVMValueRef *ConstantVals, unsigned Count,
      |                  ^~~~~~~~~~~~~~~
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Deprecated.h:29:3: note: in definition of macro ‘LLVM_ATTRIBUTE_C_DEPRECATED’
   29 |   decl __attribute__((deprecated))
      |   ^~~~
cgo-gcc-prolog: In function ‘_cgo_2ad2ad839789_Cfunc_LLVMGetGlobalContext’:
cgo-gcc-prolog:4229:2: warning: ‘LLVMGetGlobalContext’ is deprecated [-Wdeprecated-declarations]
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Core.h:593:44: note: declared here
  593 | LLVM_ATTRIBUTE_C_DEPRECATED(LLVMContextRef LLVMGetGlobalContext(void),
      |                                            ^~~~~~~~~~~~~~~~~~~~
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Deprecated.h:29:3: note: in definition of macro ‘LLVM_ATTRIBUTE_C_DEPRECATED’
   29 |   decl __attribute__((deprecated))
      |   ^~~~
cgo-gcc-prolog: In function ‘_cgo_2ad2ad839789_Cfunc_LLVMGetMDKindID’:
cgo-gcc-prolog:4597:2: warning: ‘LLVMGetMDKindID’ is deprecated [-Wdeprecated-declarations]
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Core.h:669:14: note: declared here
  669 |     unsigned LLVMGetMDKindID(const char *Name, unsigned SLen),
      |              ^~~~~~~~~~~~~~~
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Deprecated.h:29:3: note: in definition of macro ‘LLVM_ATTRIBUTE_C_DEPRECATED’
   29 |   decl __attribute__((deprecated))
      |   ^~~~
cgo-gcc-prolog: In function ‘_cgo_2ad2ad839789_Cfunc_LLVMInsertBasicBlock’:
cgo-gcc-prolog:5664:2: warning: ‘LLVMInsertBasicBlock’ is deprecated [-Wdeprecated-declarations]
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Core.h:3739:23: note: declared here
 3739 |     LLVMBasicBlockRef LLVMInsertBasicBlock(LLVMBasicBlockRef InsertBeforeBB,
      |                       ^~~~~~~~~~~~~~~~~~~~
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Deprecated.h:29:3: note: in definition of macro ‘LLVM_ATTRIBUTE_C_DEPRECATED’
   29 |   decl __attribute__((deprecated))
      |   ^~~~
cgo-gcc-prolog: In function ‘_cgo_2ad2ad839789_Cfunc_LLVMStructType’:
cgo-gcc-prolog:8039:2: warning: ‘LLVMStructType’ is deprecated [-Wdeprecated-declarations]
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Core.h:1580:17: note: declared here
 1580 |     LLVMTypeRef LLVMStructType(LLVMTypeRef *ElementTypes, unsigned ElementCount,
      |                 ^~~~~~~~~~~~~~
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Deprecated.h:29:3: note: in definition of macro ‘LLVM_ATTRIBUTE_C_DEPRECATED’
   29 |   decl __attribute__((deprecated))
      |   ^~~~
ok  	github.com/tinygo-org/tinygo/builder	48.021s
```
